### PR TITLE
Test Numeral Edge Case

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -19,6 +19,10 @@ describe("find intact classes", () => {
     it("can find .triple-simple-class", () => {
         expect(result.includes(".triple-simple-class") === true).toBe(true)
     })
+
+    it("does not remove unused with used prefix", () => {
+        expect(result.includes(".single3") === true).toBe(true)
+    })
 })
 
 describe("callback", () => {

--- a/__tests__/test_examples/simple/simple.css
+++ b/__tests__/test_examples/simple/simple.css
@@ -2,6 +2,14 @@
   color: black;
 }
 
+.single3 {
+  color: black;
+}
+
+.single-foobar {
+  color: black;
+}
+
 .double-class {
   color: black;
 }


### PR DESCRIPTION
Purify fails to remove unused CSS selectors with used prefix identifiers. i.e. if CSS class `.single {}` is used, `.single3{}` will not be removed.

![screen shot 2017-12-11 at 10 10 38](https://user-images.githubusercontent.com/17295175/33819523-fdbd7092-de5b-11e7-8477-3d7e3c377e3c.jpg)
![screen shot 2017-12-11 at 10 18 58](https://user-images.githubusercontent.com/17295175/33819684-be3d362c-de5c-11e7-9cf2-f78bf55664ce.jpg)
